### PR TITLE
Change to input widget

### DIFF
--- a/qled.cpp
+++ b/qled.cpp
@@ -27,7 +27,7 @@
   \param parent: The Parent Widget
 */
 QLed::QLed(QWidget *parent)
-    : QWidget(parent),
+    : QAbstractButton(parent),
       m_value(false),
       m_onColor("Red"),
       m_offColor("Grey"),
@@ -35,6 +35,8 @@ QLed::QLed(QWidget *parent)
       renderer(new QSvgRenderer())
 {
     shapes << "circle" << "square" << "triang" << "round" << "rect";
+    setMouseTracking(true);
+    setAttribute(Qt::WA_MacShowFocusRect);
     updateRenderer();
 }
 

--- a/qled.cpp
+++ b/qled.cpp
@@ -35,6 +35,7 @@ QLed::QLed(QWidget *parent)
       renderer(new QSvgRenderer())
 {
     shapes << "circle" << "square" << "triang" << "round" << "rect";
+    setCheckable(true);
     setMouseTracking(true);
     setAttribute(Qt::WA_MacShowFocusRect);
     updateRenderer();
@@ -59,13 +60,26 @@ void QLed::paintEvent(QPaintEvent *)
 }
 
 
+void QLed::checkStateSet()
+{
+    updateRenderer();
+}
+
+
+void QLed::nextCheckState()
+{
+    QAbstractButton::nextCheckState();
+    updateRenderer();
+}
+
+
 /*!
   \brief updateRenderer: this updates the renderer to contain the correct data for the current properties
   \return void
 */
 void QLed::updateRenderer()
 {
-    QColor currentColor = m_value ? m_onColor : m_offColor;
+    QColor currentColor = m_value || isChecked() ? m_onColor : m_offColor;
 
     QString filePathTemplate(":/resources/%1.svg");
     QString filePath = filePathTemplate.arg(shapes[m_shape]);

--- a/qled.h
+++ b/qled.h
@@ -56,6 +56,8 @@ protected:
     ledShape m_shape;
     QStringList shapes;
     void paintEvent(QPaintEvent *event) override;
+    void checkStateSet() override;
+    void nextCheckState() override;
 private:
     void updateRenderer();
     QSvgRenderer *renderer;

--- a/qled.h
+++ b/qled.h
@@ -17,7 +17,7 @@
 #define QLED_H
 
 #include <Qt>
-#include <QWidget>
+#include <QAbstractButton>
 #include <QtDesigner/QDesignerExportWidget>
 
 // My Qt designer widget plugin class
@@ -25,7 +25,7 @@
 class QColor;
 class QSvgRenderer;
 
-class QDESIGNER_WIDGET_EXPORT QLed : public QWidget
+class QDESIGNER_WIDGET_EXPORT QLed : public QAbstractButton
 {
     Q_OBJECT
     Q_ENUMS (ledShape)


### PR DESCRIPTION
This PR changes the QLed widget to a button that can optionally be made checkable.

Since a button that is not checkable does not have a `checked` property (it is always `false`) the color to be used can be controlled by the `value` property as before.